### PR TITLE
Adds releaseBtc method

### DIFF
--- a/abis/bridge.json
+++ b/abis/bridge.json
@@ -954,6 +954,13 @@
     ]
   },
   {
+    "name": "releaseBtc",
+    "type": "function",
+    "constant": true,
+    "inputs": [],
+    "outputs": []
+  },
+  {
     "anonymous": false,
     "inputs": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rsksmart/rsk-precompiled-abis",
-  "version": "5.0.0-HOP",
+  "version": "5.0.1-HOP",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rsksmart/rsk-precompiled-abis",
-      "version": "5.0.0-HOP",
+      "version": "5.0.1-HOP",
       "license": "ISC",
       "dependencies": {
         "web3": "^1.3.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rsk-precompiled-abis",
-  "version": "5.0.0-HOP",
+  "version": "5.0.1-HOP",
   "description": "Utility to interact with RSK native contracts",
   "main": "index.js",
   "repository": {

--- a/tests/bridge.test.js
+++ b/tests/bridge.test.js
@@ -8,7 +8,7 @@ describe('Bridge', () => {
     });
 
     it('has all the expected signatures', () => {
-        assert.equal(bridge.abi.length, 66);
+        assert.equal(bridge.abi.length, 73);
     });
 
     it('builds a valid contract', () => {


### PR DESCRIPTION
The reason why I'm adding this method to the abis is because the bridge has a 'releaseBtc' method which is not in the abis.
The reason this method is not in the abis is because this is the fallback method and is not necessary to call it, since this is the one executed by default when no method (no data, or '0x') is specified.

One escenario that we may face is that a user may call the bridge, manually specifying to execute this method. Since this method is not in the precompiled-abis, it is not being shown as an option in our API.