### PR TITLE
Update precompiled-abis to include getStateForSvpClient

### DIFF
--- a/abis/bridge.json
+++ b/abis/bridge.json
@@ -24,6 +24,18 @@
     ]
   },
   {
+    "name": "getStateForSvpClient",
+    "type": "function",
+    "constant": "true",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
     "name": "getStateForDebugging",
     "type": "function",
     "constant": "true",

--- a/tests/bridge.test.js
+++ b/tests/bridge.test.js
@@ -8,7 +8,7 @@ describe('Bridge', () => {
     });
 
     it('has all the expected signatures', () => {
-        assert.equal(bridge.abi.length, 76);
+        assert.equal(bridge.abi.length, 77);
     });
 
     it('builds a valid contract', () => {


### PR DESCRIPTION
### Summary

Update precompiled-abis to include new  `getStateForSvpClient` Bridge method.