### PR TITLE
Update dependabot workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    versioning-strategy: increase
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
- Run weekly instead of daily
- Ignore patch updates
- Group minor version bumps in a single PR for all dependencies
- Major version upgrades are still done in their own PR